### PR TITLE
Adding aws ecr option to avoid docker login error

### DIFF
--- a/2-containerized/deploy.sh
+++ b/2-containerized/deploy.sh
@@ -36,7 +36,7 @@ VPCID=${RESULTS_ARRAY[4]}
 
 printf "${PRIMARY}* Authenticating with EC2 Container Repository${NC}\n";
 
-`aws ecr get-login --region $REGION`
+`aws ecr get-login --region $REGION --no-include-email`
 
 # Tag for versioning the container images, currently set to timestamp
 TAG=`date +%s`

--- a/3-microservices/deploy.sh
+++ b/3-microservices/deploy.sh
@@ -38,7 +38,7 @@ VPCID=${RESULTS_ARRAY[4]}
 
 printf "${PRIMARY}* Authenticating with EC2 Container Repository${NC}\n";
 
-`aws ecr get-login --region $REGION`
+`aws ecr get-login --region $REGION --no-include-email`
 
 # Tag for versioning the container images, currently set to timestamp
 TAG=`date +%s`


### PR DESCRIPTION
# What

Adding `--no-include-email` to the `aws ecr get-login` command in the `deploy.sh` scripts for cases number 2 and 3

# Why

the `aws ecr get-login` command was triggering an error (`unknown shorthand flag: 'e' in -e`) while login into the repo which prevents the `docker push` commands to succeed 

