### PR TITLE
fix: Add name and version fields in package.json files

### DIFF
--- a/1-no-container/package.json
+++ b/1-no-container/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "node-server",
+  "version": "1.0.0",
   "dependencies": {
     "koa": "^1.2.5",
     "koa-router": "^5.4.0"

--- a/2-containerized/services/api/package.json
+++ b/2-containerized/services/api/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "node-server",
+  "version": "1.0.0",
   "dependencies": {
     "koa": "^1.2.5",
     "koa-router": "^5.4.0"

--- a/3-microservices/services/posts/package.json
+++ b/3-microservices/services/posts/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "posts",
+  "version": "1.0.0",
   "dependencies": {
     "koa": "^1.2.5",
     "koa-router": "^5.4.0"

--- a/3-microservices/services/threads/package.json
+++ b/3-microservices/services/threads/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "threads",
+  "version": "1.0.0",
   "dependencies": {
     "koa": "^1.2.5",
     "koa-router": "^5.4.0"

--- a/3-microservices/services/users/package.json
+++ b/3-microservices/services/users/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "users",
+  "version": "1.0.0",
   "dependencies": {
     "koa": "^1.2.5",
     "koa-router": "^5.4.0"


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/amazon-ecs-nodejs-microservices/issues/21

*Description of changes:*
 https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields - `A package.json file must contain “name” and “version” fields.`

So, I have updated the package.json files and added the name and version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
